### PR TITLE
TDD de base + durcissement /purchasePlaces + page /points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ lib
 tests/
 .envrc
 __pycache__
+.venv/
+__pycache__/
+*.pyc
+.env

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/Python_Testing.iml
+++ b/.idea/Python_Testing.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.13 (Python_Testing)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,16 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="CssUnknownProperty" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myCustomPropertiesEnabled" value="true" />
+      <option name="myIgnoreVendorSpecificProperties" value="false" />
+      <option name="myCustomPropertiesList">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="mheight" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.13 (Python_Testing)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 (Python_Testing)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Python_Testing.iml" filepath="$PROJECT_DIR$/.idea/Python_Testing.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/server.py
+++ b/server.py
@@ -15,45 +15,111 @@ def loadCompetitions():
 
 
 app = Flask(__name__)
-app.secret_key = 'something_special'
+app.secret_key = "something_secret_for_flash"  # en prod: variable d'env
 
-competitions = loadCompetitions()
 clubs = loadClubs()
+competitions = loadCompetitions()
 
-@app.route('/')
+# suivi cumulatif des réservations par (club, competition)
+club_bookings = {}  # clé: (club_name, comp_name) -> int
+
+def find_club_by_name(name):
+    return next((c for c in clubs if c["name"] == name), None)
+
+def find_comp_by_name(name):
+    return next((c for c in competitions if c["name"] == name), None)
+
+def validate_purchase(club, competition, places_required, current_booked=0):
+    """
+    Règles:
+      - places_required entier > 0
+      - cumul par club par compétition <= 12
+      - places_required <= places restantes de la compétition
+      - points du club >= places_required (1 point = 1 place)
+    """
+    try:
+        n = int(places_required)
+    except (TypeError, ValueError):
+            return False, "Invalid quantity"
+    if n <= 0:
+        return False, "Invalid quantity (>=1)"
+
+    # disponibilité compétition
+    comp_left = int(competition["numberOfPlaces"])
+    if n > comp_left:
+        return False, "Pas assez de places disponibles"
+
+    # points du club
+    club_pts = int(club["points"])
+    if n > club_pts:
+        return False, "Pas assez de points"
+
+    # plafond 12 par club et par compétition (cumulé)
+    if current_booked + n > 12:
+        return False, "Maximum 12 places par club sur une compétition"
+
+    return True, None
+
+@app.route("/")
 def index():
-    return render_template('index.html')
+    return render_template("index.html")
 
-@app.route('/showSummary',methods=['POST'])
+@app.route("/showSummary", methods=["POST"])
 def showSummary():
-    club = [club for club in clubs if club['email'] == request.form['email']][0]
-    return render_template('welcome.html',club=club,competitions=competitions)
+    email = request.form.get("email", "")
+    club = next((c for c in clubs if c["email"] == email), None)
+    if not club:
+        flash("Email inconnu")
+        return redirect(url_for("index"))
+    return render_template("welcome.html", club=club, competitions=competitions)
 
+@app.route("/book/<competition>/<club>")
+def book(competition, club):
+    foundClub = find_club_by_name(club)
+    foundCompetition = find_comp_by_name(competition)
+    if not foundClub or not foundCompetition:
+        flash("Club ou compétition introuvable")
+        return redirect(url_for("index"))
+    return render_template("booking.html", club=foundClub, competition=foundCompetition)
 
-@app.route('/book/<competition>/<club>')
-def book(competition,club):
-    foundClub = [c for c in clubs if c['name'] == club][0]
-    foundCompetition = [c for c in competitions if c['name'] == competition][0]
-    if foundClub and foundCompetition:
-        return render_template('booking.html',club=foundClub,competition=foundCompetition)
-    else:
-        flash("Something went wrong-please try again")
-        return render_template('welcome.html', club=club, competitions=competitions)
-
-
-@app.route('/purchasePlaces',methods=['POST'])
+@app.route("/purchasePlaces", methods=["POST"])
 def purchasePlaces():
-    competition = [c for c in competitions if c['name'] == request.form['competition']][0]
-    club = [c for c in clubs if c['name'] == request.form['club']][0]
-    placesRequired = int(request.form['places'])
-    competition['numberOfPlaces'] = int(competition['numberOfPlaces'])-placesRequired
-    flash('Great-booking complete!')
-    return render_template('welcome.html', club=club, competitions=competitions)
+    comp_name = request.form.get("competition")
+    club_name = request.form.get("club")
+    places_str = request.form.get("places", "0")
 
+    competition = find_comp_by_name(comp_name)
+    club = find_club_by_name(club_name)
 
-# TODO: Add route for points display
+    if not competition or not club:
+        flash("Données invalides (club/compétition)")
+        return redirect(url_for("index"))
 
+    booked = club_bookings.get((club["name"], competition["name"]), 0)
 
-@app.route('/logout')
+    ok, msg = validate_purchase(club, competition, places_str, current_booked=booked)
+    if not ok:
+        flash(msg)
+        # on reste sur la page de synthèse du club
+        return render_template("welcome.html", club=club, competitions=competitions)
+
+    n = int(places_str)
+
+    # appliquer la réservation
+    competition["numberOfPlaces"] = str(int(competition["numberOfPlaces"]) - n)
+    club["points"] = str(int(club["points"]) - n)
+    club_bookings[(club["name"], competition["name"])] = booked + n
+
+    flash("Great-booking complete!")  # garde le texte d'origine pour que les tests passent
+    return render_template("welcome.html", club=club, competitions=competitions)
+
+# (Phase 2) affichage public des points — simple, sans login
+@app.route("/points")
+def points():
+    # rendu minimaliste sans template dédié (tu pourras faire un template plus tard)
+    rows = [f"<li>{c['name']}: {c['points']} points</li>" for c in clubs]
+    return "<h2>Points par club</h2><ul>" + "\n".join(rows) + "</ul>"
+
+@app.route("/logout")
 def logout():
-    return redirect(url_for('index'))
+    return redirect(url_for("index"))


### PR DESCRIPTION
### Objet
Durcissement du flux d’achat + TDD de base + page /points.

### Contenu
- Tests unitaires règles d’achat
- Tests d’intégration (login + achat)
- validate_purchase + contrôle strict /purchasePlaces
- Décrément des points et places
- /points (lecture seule)

### Comment tester
- `pytest -q`
- Scénario: login Simply Lift -> achat 3 places -> vérifier points/places
